### PR TITLE
updated menu to display "Assets"

### DIFF
--- a/ams-ng/src/app/core/menu/menu.component.ts
+++ b/ams-ng/src/app/core/menu/menu.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 // import { SystemService } from '../shared/services/system.service';
 import { User } from '../../shared/models/User';
-
+import { Asset } from '../../shared/models/asset';
 //imports menu.ts file
 import { Menu } from './menu';
 
@@ -21,7 +21,7 @@ export class MenuComponent implements OnInit {
     new Menu("LOGIN ", "/login", "Login menu item"),
   	new Menu("USERS ", "/users", "Users menu item"),
   	// new Menu("VENDORS ", "/vendors", "Vendor menu item"),
-  	// new Menu("ASSETS ", "/assets", "Asset menu item"),
+  	new Menu("ASSETS ", "/assets", "Asset menu item"),
   	// new Menu("VEHICLES ", "/vehicles", "Vehicles menu item"),
   	// new Menu("RECORDS ", "/records", "Records menu item"),
   	// new Menu("DOCUMENTS ", "/documents", "Documents menu item"),


### PR DESCRIPTION
Line 4 now says: import { Asset } from '../../shared/models/asset';, and Line 24 was uncommented to say: "new Menu("ASSETS ", "/assets", "Asset menu item"),